### PR TITLE
Added -std=c++17 flag to suppress warning during compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(imnav_goal)
 
+add_compile_options(-std=c++17)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs


### PR DESCRIPTION
Current CMake configuration results with warning like this.
```bash
imnav_goal/src/imnav_goal_node.cpp:41:10: warning: structured bindings only available with ‘-std=c++17’ or ‘-std=gnu++17’
   41 |     auto [origin_x, origin_y, origin_zone] = gpsToUTM(origin_gps_.latitude, origin_gps_.longitude);
      |          ^
```
So I added ```-std=c++17``` compile option flag to suppress this warning.